### PR TITLE
Get refresh rate kwargs working

### DIFF
--- a/astrostash/__init__.py
+++ b/astrostash/__init__.py
@@ -1,8 +1,10 @@
 from .astrostash import SQLiteDB
 from .astrostash import sha256sum
+from .astrostash import needs_refresh
 
 
 __all__ = [
     "SQLiteDB",
     "sha256sum",
+    "needs_refresh",
 ]

--- a/astrostash/astrostash.py
+++ b/astrostash/astrostash.py
@@ -42,6 +42,27 @@ def make_result_hash(df: pd.DataFrame) -> str:
     return sha256sum(pdhash)
 
 
+def needs_refresh(last_refreshed: str, refresh_rate: int) -> bool:
+    """
+    Determins a if a refresh is needed based off of the set refresh rate and
+    the last refresh date
+
+    Parameters:
+    last_refreshed: str, date of last refresh in format YYYY-MM-DD
+
+    refresh_rate: int, number of days before a refresh in needed
+
+    Returns:
+    bool, True if refresh is needed, False if not
+    """
+    need = False
+    today = datetime.today().date()
+    last = datetime.strptime(last_refreshed, '%Y-%m-%d').date()
+    if (today - last).days >= refresh_rate:
+        need = True
+    return need
+
+
 class SQLiteDB:
     def __init__(self, db_name=None):
         db_name = self._get_db_file(db_name)

--- a/astrostash/astrostash.py
+++ b/astrostash/astrostash.py
@@ -89,6 +89,26 @@ class SQLiteDB:
                                params={"query_hash": query_hash})
         return stashref
 
+    def get_refresh_rate(self, qid: int) -> int | None:
+        """
+        Gets the refresh rate (in days) associated with a query id (if exists)
+        If no refresh rate exists returns None
+
+        Parameters:
+        qid: int, id associated with a unique query
+
+        Returns:
+        int, refresh rate in days or None if no refresh rate exists
+        """
+        self.cursor.execute("""SELECT refresh_rate FROM queries
+                               WHERE id = :qid;""",
+                            {"qid": qid})
+        refresh_rate = self.cursor.fetchone()
+        try:
+            return refresh_rate[0]
+        except TypeError:
+            return refresh_rate
+
     def _check_table_exists(self, name: str) -> bool:
         """
         Checks to ensure that a user specified table exists in the database

--- a/astrostash/astrostash.py
+++ b/astrostash/astrostash.py
@@ -364,6 +364,10 @@ class SQLiteDB:
         qdf = self.get_query(query_hash)
         try:
             qid = int(qdf["id"].iloc[0])
+            q_refresh_rate = self.get_refresh_rate(qid)
+            last_refresh_date = qdf["last_refreshed"].iloc[0]
+            if q_refresh_rate is not None and refresh is not True:
+                refresh = needs_refresh(last_refresh_date, q_refresh_rate)
         except IndexError:
             qid = None
         if qdf.empty is True or refresh is True:

--- a/astrostash/astrostash.py
+++ b/astrostash/astrostash.py
@@ -365,6 +365,9 @@ class SQLiteDB:
         try:
             qid = int(qdf["id"].iloc[0])
             q_refresh_rate = self.get_refresh_rate(qid)
+            if refresh_rate is not None and refresh_rate != q_refresh_rate:
+                q_refresh_rate = refresh_rate
+                self.update_refresh_rate(qid, refresh_rate)
             last_refresh_date = qdf["last_refreshed"].iloc[0]
             if q_refresh_rate is not None and refresh is not True:
                 refresh = needs_refresh(last_refresh_date, q_refresh_rate)

--- a/astrostash/heasarc/tests/test_heasarc.py
+++ b/astrostash/heasarc/tests/test_heasarc.py
@@ -35,6 +35,11 @@ def test_query_region():
     pos = SkyCoord.from_name('ngc 3783')
     ngc_table = heasarc.query_region(position=pos, catalog='numaster')
     assert heasarc.ldb._check_table_exists("numaster") is True
+    ngc_table = heasarc.query_region(
+        position=pos,
+        catalog='numaster',
+        refresh_rate=30)
+    assert heasarc.ldb.get_refresh_rate(2) == 30
     os.remove("astrostash.db")
 
 
@@ -49,7 +54,7 @@ def test_query_object(cleanup_copies):
     shutil.copy(db, dbcopy)
     heasarc2 = Heasarc(db_name=dbcopy)
     crab_refresh = heasarc2.query_object(
-        "crab", catalog="nicermastr", refresh=True
+        "crab", catalog="nicermastr", refresh_rate=2
         )
     changed_row = crab_refresh.loc[crab_refresh["__row"] == "43561"]
     assert len(changed_row) == 1

--- a/astrostash/tests/test_astrostash_core.py
+++ b/astrostash/tests/test_astrostash_core.py
@@ -1,6 +1,7 @@
 import astrostash
 import os
 import pathlib as pl
+from datetime import datetime
 
 
 def test_sha256sum():
@@ -9,6 +10,12 @@ def test_sha256sum():
         "catalog": "xtemaster"
         }
     astrostash.sha256sum(query_params)
+
+
+def test_need_refresh():
+    assert astrostash.needs_refresh("2020-01-01", 5) is True
+    d2 = datetime.today().strftime('%Y-%m-%d')
+    assert astrostash.needs_refresh(d2, 5) is False
 
 
 def test_SQLiteDB():

--- a/astrostash/tests/test_astrostash_core.py
+++ b/astrostash/tests/test_astrostash_core.py
@@ -24,6 +24,13 @@ def test_SQLiteDB():
     assert id1 == 1
     # Test getting query that already exists
     assert sql1.get_query(qp_hash).hash[0] == qp_hash
+    refresh_rate1 = sql1.get_refresh_rate(id1)
+    assert refresh_rate1 == 14
+    refresh_rate1 = sql1.get_refresh_rate(2)
+    assert refresh_rate1 is None
+    qp["catalog"] = "xtemaster"
+    qp_hash2 = astrostash.sha256sum(qp)
+    id2 = sql1.insert_query(qp_hash2, None)
     sql1.close()
     os.remove("astrostash.db")
     sql2 = astrostash.SQLiteDB(db_name="astrostash/tests/astrostash_test.db")


### PR DESCRIPTION
This PR adds in functionality to allow the `refresh_rate` kwargs working throughout astrostash.

This changes accomplish this by:

-  Adding in `SQLiteDB.get_refresh_rate()` to get the refresh rate associated with a query.
- Creating `needs_refresh()` to determine if a refresh for a query is warrented
- Adding extra logic and conditional statements to `SQLiteDB.fetch_sync()` to allow for refresh rate information to be gathered, updated, and compared.