### PR TITLE
Improve `SQLiteDB.delete_table_row()` security

### DIFF
--- a/astrostash/astrostash.py
+++ b/astrostash/astrostash.py
@@ -295,7 +295,9 @@ class SQLiteDB:
                     f"DELETE FROM {table_name} WHERE {idcol} = :rowid;",
                     {"rowid": rowid}
                 )
-        self.conn.commit()
+            self.conn.commit()
+        else:
+            raise ValueError(f"{table_name} does not exist")
 
     def ingest_table(self, table, name, if_exists="append") -> None:
         """

--- a/astrostash/astrostash.py
+++ b/astrostash/astrostash.py
@@ -289,8 +289,12 @@ class SQLiteDB:
                     deleted
         """
         if self._check_table_exists(table_name) is True:
-            self.cursor.execute(f""" DELETE FROM {table_name}
-                                     WHERE {idcol} = {rowid};""")
+            columns = self.get_columns(table_name)
+            if idcol in columns:
+                self.cursor.execute(
+                    f"DELETE FROM {table_name} WHERE {idcol} = :rowid;",
+                    {"rowid": rowid}
+                )
         self.conn.commit()
 
     def ingest_table(self, table, name, if_exists="append") -> None:

--- a/astrostash/tests/test_astrostash_core.py
+++ b/astrostash/tests/test_astrostash_core.py
@@ -2,6 +2,7 @@ import astrostash
 import os
 import pathlib as pl
 from datetime import datetime
+import pytest
 
 
 def test_sha256sum():
@@ -31,6 +32,11 @@ def test_SQLiteDB():
     assert id1 == 1
     # Test getting query that already exists
     assert sql1.get_query(qp_hash).hash[0] == qp_hash
+    queries_columns = sql1.get_columns("queries")
+    expected_queries_columns = ['id', 'hash', 'last_refreshed', 'refresh_rate']
+    assert queries_columns == expected_queries_columns
+    with pytest.raises(ValueError):
+        bad_table_name = sql1.get_columns("xxx")
     refresh_rate1 = sql1.get_refresh_rate(id1)
     assert refresh_rate1 == 14
     refresh_rate1 = sql1.get_refresh_rate(2)

--- a/astrostash/tests/test_astrostash_core.py
+++ b/astrostash/tests/test_astrostash_core.py
@@ -37,6 +37,10 @@ def test_SQLiteDB():
     assert queries_columns == expected_queries_columns
     with pytest.raises(ValueError):
         bad_table_name = sql1.get_columns("xxx")
+        sql1.delete_table_row("queries; DROP TABLE nicermastr", "__row", 2)
+        sql1.delete_table_row("nicermastr", "__row ; DROP TABLE queries", 2)
+    assert sql1._check_table_exists("nicermastr") is True
+    assert sql1._check_table_exists("queries") is True
     refresh_rate1 = sql1.get_refresh_rate(id1)
     assert refresh_rate1 == 14
     refresh_rate1 = sql1.get_refresh_rate(2)


### PR DESCRIPTION
Before beginning, I am well aware of the security issue still present with using f-strings.
However, this PR adds code that definitely helps improve the situation with better sanitation of arguments through the creation of `SQLiteDB.get_columns()`, added error handling, and testing.

#5 is already documenting this issue more broadly and an alternative work around is required to get it solved.