### PR TITLE
Add modular tests for SQLiteDB class

### DIFF
--- a/astrostash/tests/test_astrostash_core.py
+++ b/astrostash/tests/test_astrostash_core.py
@@ -118,6 +118,8 @@ def test_update_refresh_rate(setup_sqlite_db):
     assert queryid == updateid
     query = sql.get_query(query_hash)
     assert query['refresh_rate'][0] == 8
+    queryid2 = sql._get_queryid(query, False, refresh_rate=20)[0]
+    assert queryid == queryid2
 
 
 def test_fetch_sync(setup_sqlite_db):

--- a/astrostash/tests/test_astrostash_core.py
+++ b/astrostash/tests/test_astrostash_core.py
@@ -99,6 +99,17 @@ def test_update_last_refreshed(setup_sqlite_db):
     assert row_updated == 1
 
 
+def test_update_refresh_rate(setup_sqlite_db):
+    sql = setup_sqlite_db[0]
+    query_params = {"query": "PSR B0531+21", "catalog": "numaster"}
+    query_hash = astrostash.sha256sum(query_params)
+    queryid = sql.insert_query(query_hash, 7)
+    updateid = sql.update_refresh_rate(1, 8)
+    assert queryid == updateid
+    query = sql.get_query(query_hash)
+    assert query['refresh_rate'][0] == 8
+
+
 def test_fetch_sync(setup_sqlite_db):
     sql, db_path = setup_sqlite_db
 

--- a/astrostash/tests/test_astrostash_core.py
+++ b/astrostash/tests/test_astrostash_core.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import pytest
 import pandas as pd
 from astropy.table import Table
+from astropy.coordinates import SkyCoord
 from unittest.mock import MagicMock
 
 
@@ -13,7 +14,16 @@ def test_sha256sum():
         "query": "PSR B0531+21",
         "catalog": "xtemaster"
         }
-    astrostash.sha256sum(query_params)
+    object_hash = astrostash.sha256sum(query_params)
+
+    region_query_params = {
+        "query": SkyCoord.from_name("PSR B0531+21"),
+        "catalog": "xtemaster"
+        }
+    region_hash = astrostash.sha256sum(region_query_params)
+    # assert no change to query dtype
+    assert isinstance(region_query_params["query"], SkyCoord)
+    assert object_hash != region_hash
 
 
 def test_need_refresh():

--- a/astrostash/tests/test_astrostash_core.py
+++ b/astrostash/tests/test_astrostash_core.py
@@ -88,6 +88,17 @@ def test_get_refresh_rate(setup_sqlite_db):
     assert sql.get_refresh_rate(2) is None
 
 
+def test_update_last_refreshed(setup_sqlite_db):
+    sql = setup_sqlite_db[0]
+    query_params = {"query": "PSR B0531+21", "catalog": "xtemaster"}
+    query_hash = astrostash.sha256sum(query_params)
+    sql.insert_query(query_hash, None)
+    today = datetime.today().strftime('%Y-%m-%d')
+    assert sql.get_query(query_hash)["last_refreshed"][0] == today
+    row_updated = sql.update_last_refreshed(1)
+    assert row_updated == 1
+
+
 def test_fetch_sync(setup_sqlite_db):
     sql, db_path = setup_sqlite_db
 


### PR DESCRIPTION
This PR improves testing by creating modular tests for the `SQLiteDB` class.

The following tests have been created with mocking to allow for local testing of `SQLiteDB`:

- `test_update_last_refreshed`
- `test_update_refresh_rate`
- `test_fetch_sync`

Also testing was extended and enhanced for `test_sha256sum`