### PR TITLE
Add support for querying locally only

### DIFF
--- a/astrostash/astrostash.py
+++ b/astrostash/astrostash.py
@@ -541,7 +541,8 @@ class SQLiteDB:
         Returns:
         pd.DataFrame, table with the results of the query
         """
-        del query_params["refresh_rate"], query_params["refresh"]
+        query_params.pop("refresh_rate", None)
+        query_params.pop("refresh", None)
         query_hash = sha256sum(query_params)
         qdf = self.get_query(query_hash)
         qid, refresh = self._get_queryid(qdf, refresh, refresh_rate)

--- a/astrostash/astrostash.py
+++ b/astrostash/astrostash.py
@@ -267,17 +267,18 @@ class SQLiteDB:
 
     def insert_response_rowid_pivot(self,
                                     responseid: int,
-                                    rowid: str) -> None:
+                                    rowid: list[str]) -> None:
         """
-        Inserts a response id and generic rowid pair
+        Inserts response id and rowid pair(s)
 
         Parameters:
         responseid: int, response id from responses table
 
-        rowid: str, id associated with a unique row (obsid, name, doi)
-                    of an external table (nicermastr, heasarc_catalog_list)
+        rowid: list of str, id(s) associated with unique row(s)
+                    (obsid, name, doi) of an external table
+                    (nicermastr, heasarc_catalog_list)
         """
-        self.cursor.execute(
+        self.cursor.executemany(
             """ INSERT INTO response_rowid_pivot (
                 responseid,
                 rowid
@@ -286,7 +287,7 @@ class SQLiteDB:
                 :responseid,
                 :rowid
             );""",
-            {"responseid": responseid, "rowid": rowid})
+            [{"responseid": responseid, "rowid": r} for r in rowid])
         self.conn.commit()
 
     def _ingest_response_and_links(self, df: pd.DataFrame, qid: int,
@@ -308,8 +309,7 @@ class SQLiteDB:
         if rid is None:
             rid = self.insert_response(response_hash)
             self.insert_query_response_pivot(qid, rid)
-            for rowid in df[idcol].values:
-                self.insert_response_rowid_pivot(rid, rowid)
+            self.insert_response_rowid_pivot(rid, df[idcol].tolist())
         elif self._check_query_response_link(qid, rid[0]) == 0:
             self.insert_query_response_pivot(qid, rid[0])
 

--- a/astrostash/astrostash.py
+++ b/astrostash/astrostash.py
@@ -684,7 +684,7 @@ class SQLiteDB:
                       spatial region
         """
         self._validate_spatial_table(table)
-        df = pd.read_sql(f'SELECT * FROM "{table}"', self.conn)
+        df = pd.read_sql_table(table, self.aconn)
         if df.empty:
             return df
         ra = df['ra'].to_numpy()

--- a/astrostash/astrostash.py
+++ b/astrostash/astrostash.py
@@ -2,10 +2,13 @@ import pathlib as pl
 import sqlite3
 from sqlalchemy import create_engine
 import pandas as pd
+import numpy as np
 from datetime import datetime
 import hashlib
 import json
 import astropy
+from astropy.coordinates import SkyCoord, Angle
+from astropy import units as u
 from importlib.resources import files
 
 
@@ -142,6 +145,78 @@ class SQLiteDB:
                                name = :name LIMIT 1;""",
                             {"name": name})
         return self.cursor.fetchone() is not None
+
+    def _validate_spatial_table(self, table: str) -> None:
+        """
+        Validates that a table exists and has ra/dec columns
+
+        Parameters:
+        table: str, name of table to validate
+
+        Raises:
+        ValueError, if table doesn't exist or lacks ra/dec columns
+        """
+        if not self._check_table_exists(table):
+            raise ValueError(
+                f"Table '{table}' does not exist in {self.db_name}")
+        cols = [c.lower() for c in self.get_columns(table)]
+        if "ra" not in cols or "dec" not in cols:
+            raise ValueError(
+                f"Table '{table}' has no 'ra' and 'dec' columns")
+
+    def _normalize_position(self, position) -> SkyCoord:
+        """
+        Normalizes a position to a SkyCoord object
+
+        Parameters:
+        position: SkyCoord or str, coordinate position
+
+        Returns:
+        SkyCoord, normalized coordinate object
+        """
+        if isinstance(position, SkyCoord):
+            return position
+        return SkyCoord(position)
+
+    def _parse_angle(self, value) -> float:
+        """
+        Converts a string or Quantity angle to degrees
+
+        Parameters:
+        value: str or astropy.units.Quantity, angle value
+
+        Returns:
+        float, angle in degrees
+        """
+        if isinstance(value, str):
+            return Angle(value).deg
+        return value.to(u.deg).value
+
+    def _point_in_polygon(self, ra: np.ndarray,
+                          dec: np.ndarray,
+                          vertices: list) -> np.ndarray:
+        """
+        Vectorized ray-casting point-in-polygon test
+
+        Parameters:
+        ra: np.ndarray, right ascension values in degrees
+        dec: np.ndarray, declination values in degrees
+        vertices: list of (ra, dec) tuples in degrees outlining the polygon
+
+        Returns:
+        np.ndarray, boolean mask where True indicates point is inside polygon
+        """
+        n = len(vertices)
+        inside = np.zeros(len(ra), dtype=bool)
+        for i in range(n):
+            yi, xi = vertices[i][1], vertices[i][0]
+            yj, xj = vertices[(i - 1) % n][1], vertices[(i - 1) % n][0]
+            if yi == yj:
+                continue
+            cond = ((yi > dec) != (yj > dec)) & \
+                   (ra < (xj - xi) * (dec - yi) / (yj - yi) + xi)
+            inside ^= cond
+        return inside
 
     def get_columns(self, tablename: str) -> list:
         """
@@ -567,6 +642,97 @@ class SQLiteDB:
             # Stash the the external response in the database
             self._stash_table(df, table_name, idcol)
         return self._get_stashed_rows(table_name, qid, idcol)
+
+    def query_region(self, table: str,
+                     position=None,
+                     spatial: str = 'cone',
+                     radius=None,
+                     width=None,
+                     polygon: list = None) -> pd.DataFrame:
+        """
+        Queries a local database table for rows within a specified
+        astronomical region
+
+        Parameters:
+        table : str
+            The catalog table to query. The table must have ``ra`` and
+            ``dec`` columns.
+        position : str or `astropy.coordinates.SkyCoord`
+            Gives the position of the center of the cone or box if
+            performing a cone or box search. Required if spatial is
+            ``'cone'`` or ``'box'``. Ignored if spatial is
+            ``'polygon'`` or ``'all-sky'``.
+        spatial : str
+            Type of spatial query: ``'cone'``, ``'box'``, ``'polygon'``,
+            and ``'all-sky'``. Defaults to ``'cone'``.
+        radius : str or `~astropy.units.Quantity`, [optional for
+            spatial == ``'cone'``]
+            The string must be parsable by `~astropy.coordinates.Angle`.
+            The appropriate `~astropy.units.Quantity` object from
+            `astropy.units` may also be used.
+        width : str or `~astropy.units.Quantity`, [Required for
+            spatial == ``'box'``]
+            The string must be parsable by `~astropy.coordinates.Angle`.
+            The appropriate `~astropy.units.Quantity` object from
+            `astropy.units` may also be used.
+        polygon : list, [Required for spatial is ``'polygon'``]
+            A list of ``(ra, dec)`` pairs (as tuples), in decimal degrees,
+            outlining the polygon to search in.
+
+        Returns:
+        pd.DataFrame, rows from the table that fall within the specified
+                      spatial region
+        """
+        self._validate_spatial_table(table)
+        df = pd.read_sql(f'SELECT * FROM "{table}"', self.conn)
+        if df.empty:
+            return df
+        ra = df['ra'].to_numpy()
+        dec = df['dec'].to_numpy()
+
+        if spatial == 'all-sky':
+            return df
+
+        if spatial in ('cone', 'box'):
+            if position is None:
+                raise ValueError(
+                    "position is required for cone and box queries")
+            coord = self._normalize_position(position)
+            cra, cdec = coord.ra.deg, coord.dec.deg
+
+        if spatial == 'cone':
+            if radius is None:
+                raise ValueError("radius is required for cone queries")
+            r_deg = self._parse_angle(radius)
+            ra_rad = np.radians(ra)
+            dec_rad = np.radians(dec)
+            cra_rad = np.radians(cra)
+            cdec_rad = np.radians(cdec)
+            dlat = dec_rad - cdec_rad
+            dlon = ra_rad - cra_rad
+            a = np.sin(dlat / 2) ** 2 + \
+                np.cos(cdec_rad) * np.cos(dec_rad) * \
+                np.sin(dlon / 2) ** 2
+            dist_deg = np.degrees(2 * np.arcsin(np.sqrt(a)))
+            mask = dist_deg <= r_deg
+            return df[mask].reset_index(drop=True)
+
+        if spatial == 'box':
+            if width is None:
+                raise ValueError("width is required for box queries")
+            w_deg = self._parse_angle(width)
+            half = w_deg / 2.0
+            mask = ((ra >= cra - half) & (ra <= cra + half) &
+                    (dec >= cdec - half) & (dec <= cdec + half))
+            return df[mask].reset_index(drop=True)
+
+        if spatial == 'polygon':
+            if polygon is None:
+                raise ValueError("polygon is required for polygon queries")
+            inside = self._point_in_polygon(ra, dec, polygon)
+            return df[inside].reset_index(drop=True)
+
+        raise ValueError(f"Unknown spatial mode: '{spatial}'")
 
     def close(self):
         """

--- a/astrostash/heasarc/core.py
+++ b/astrostash/heasarc/core.py
@@ -61,7 +61,9 @@ class Heasarc:
 
     def query_region(self, position=None, catalog=None,
                      radius=None, refresh_rate=None,
-                     refresh=False, **kwargs) -> pd.DataFrame:
+                     refresh=False, local=False,
+                     spatial='cone', width=None, polygon=None,
+                     **kwargs) -> pd.DataFrame:
         """
         Queries a catalog at the heasarc for records around a specific
         region
@@ -83,14 +85,45 @@ class Heasarc:
                  Toggles call to the heasarc to refresh the query response
                  if True
 
+        local: bool, default = False
+               If True, query the local database directly for the specified
+               spatial region instead of fetching from the remote heasarc.
+               Bypasses query history lookup and remote calls.
+
+        spatial: str, default 'cone'
+                 Type of spatial query for local mode: 'cone', 'box',
+                 'polygon', or 'all-sky'. Ignored if local is False.
+
+        width: str or `~astropy.units.Quantity`, [Required for
+               spatial == 'box' in local mode]
+               Width of the box search region.
+
+        polygon: list, [Required for spatial is 'polygon' in local mode]
+                 A list of (ra, dec) pairs in decimal degrees outlining
+                 the polygon to search in.
+
         **kwargs: additional kwargs to be passed into
                    astroquery.Heasarc.query_region
 
         Returns:
         pd.DataFrame, table of catalog's records around the specified region
         """
+        if local:
+            if catalog is None:
+                raise ValueError("catalog is required for local queries")
+            return self.ldb.query_region(
+                table=catalog,
+                position=position,
+                spatial=spatial,
+                radius=radius,
+                width=width,
+                polygon=polygon)
         params = locals().copy()
         params.pop("self", None)
+        params.pop("local", None)
+        params.pop("spatial", None)
+        params.pop("width", None)
+        params.pop("polygon", None)
         if self._check_catalog_exists(catalog):
             return self.ldb.fetch_sync(self.aq.query_region,
                                        catalog,
@@ -101,7 +134,9 @@ class Heasarc:
 
     def query_object(self, object_name, catalog=None,
                      radius=None, refresh_rate=None,
-                     refresh=False, **kwargs) -> pd.DataFrame:
+                     refresh=False, local=False,
+                     spatial='cone', width=None, polygon=None,
+                     **kwargs) -> pd.DataFrame:
         """
         Queries a catalog at the heasarc for records around a specific
         object/source
@@ -121,6 +156,21 @@ class Heasarc:
                  Toggles call to the heasarc to refresh the query response
                  if True
 
+        local: bool, default = False
+               If True, query the local database directly for the specified
+               spatial region instead of fetching from the remote heasarc.
+
+        spatial: str, default 'cone'
+                 Type of spatial query for local mode: 'cone', 'box',
+                 'polygon', or 'all-sky'. Ignored if local is False.
+
+        width: str or `~astropy.units.Quantity`, optional
+               Width of the box search region for local mode.
+
+        polygon: list, optional
+                 A list of (ra, dec) pairs in decimal degrees outlining
+                 the polygon to search in for local mode.
+
         Returns:
         pd.DataFrame, table of catalog's records for the specified object
         """
@@ -130,6 +180,10 @@ class Heasarc:
                                  radius=radius,
                                  refresh_rate=refresh_rate,
                                  refresh=refresh,
+                                 local=local,
+                                 spatial=spatial,
+                                 width=width,
+                                 polygon=polygon,
                                  **kwargs)
 
     def query_tap(self, query: str, catalog: str, maxrec=None,

--- a/astrostash/heasarc/core.py
+++ b/astrostash/heasarc/core.py
@@ -38,7 +38,7 @@ class Heasarc:
         pd.DataFrame, heasarc catalogs and descriptions
         """
         params = locals().copy()
-        del params["self"]
+        params.pop("self", None)
         return self.ldb.fetch_sync(self.aq.list_catalogs,
                                    "heasarc_catalog_list",
                                    params,
@@ -84,13 +84,13 @@ class Heasarc:
                  if True
 
         **kwargs: additional kwargs to be passed into
-                  astroquery.Heasarc.query_region
+                   astroquery.Heasarc.query_region
 
         Returns:
         pd.DataFrame, table of catalog's records around the specified region
         """
         params = locals().copy()
-        del params["self"]
+        params.pop("self", None)
         if self._check_catalog_exists(catalog):
             return self.ldb.fetch_sync(self.aq.query_region,
                                        catalog,
@@ -149,9 +149,9 @@ class Heasarc:
         pd.DataFrame, response from HEASARC for the ADQL query
         """
         params = locals().copy()
-        del params["self"]
+        params.pop("self", None)
         if self._check_catalog_exists(catalog):
-            del params["catalog"]
+            params.pop("catalog", None)
             return self.ldb.fetch_sync(self.aq.query_tap,
                                        catalog,
                                        params,

--- a/astrostash/heasarc/core.py
+++ b/astrostash/heasarc/core.py
@@ -61,8 +61,8 @@ class Heasarc:
 
     def query_region(self, position=None, catalog=None,
                      radius=None, refresh_rate=None,
-                     refresh=False, local=False,
-                     spatial='cone', width=None, polygon=None,
+                     mode='standard', spatial='cone',
+                     width=None, polygon=None,
                      **kwargs) -> pd.DataFrame:
         """
         Queries a catalog at the heasarc for records around a specific
@@ -81,26 +81,27 @@ class Heasarc:
         refresh_rate: int or None, default = None,
                       time in days before the query should be refreshed
 
-        refresh: bool, default = False
-                 Toggles call to the heasarc to refresh the query response
-                 if True
-
-        local: bool, default = False
-               If True, query the local database directly for the specified
-               spatial region instead of fetching from the remote heasarc.
-               Bypasses query history lookup and remote calls.
+        mode: str, default 'standard'
+              Query mode. ``'standard'`` checks local cache first and
+              fetches from remote if no cached data exists.
+              ``'refresh'`` always fetches from remote and updates the
+              cache. ``'local'`` queries the local database directly for
+              the specified spatial region, bypassing remote calls and
+              query history lookup.
 
         spatial: str, default 'cone'
                  Type of spatial query for local mode: 'cone', 'box',
-                 'polygon', or 'all-sky'. Ignored if local is False.
+                 'polygon', or 'all-sky'. Ignored if mode is not
+                 ``'local'``.
 
         width: str or `~astropy.units.Quantity`, [Required for
-               spatial == 'box' in local mode]
+               spatial == ``'box'`` in local mode]
                Width of the box search region.
 
-        polygon: list, [Required for spatial is 'polygon' in local mode]
-                 A list of (ra, dec) pairs in decimal degrees outlining
-                 the polygon to search in.
+        polygon: list, [Required for spatial is ``'polygon'`` in local
+                 mode]
+                 A list of ``(ra, dec)`` pairs in decimal degrees
+                 outlining the polygon to search in.
 
         **kwargs: additional kwargs to be passed into
                    astroquery.Heasarc.query_region
@@ -108,7 +109,7 @@ class Heasarc:
         Returns:
         pd.DataFrame, table of catalog's records around the specified region
         """
-        if local:
+        if mode == 'local':
             if catalog is None:
                 raise ValueError("catalog is required for local queries")
             return self.ldb.query_region(
@@ -118,12 +119,18 @@ class Heasarc:
                 radius=radius,
                 width=width,
                 polygon=polygon)
+        if mode not in ('standard', 'refresh'):
+            raise ValueError(
+                f"Unknown mode: '{mode}'. "
+                "Expected 'standard', 'refresh', or 'local'")
+        refresh = (mode == 'refresh')
         params = locals().copy()
         params.pop("self", None)
-        params.pop("local", None)
+        params.pop("mode", None)
         params.pop("spatial", None)
         params.pop("width", None)
         params.pop("polygon", None)
+        params.pop("refresh", None)
         if self._check_catalog_exists(catalog):
             return self.ldb.fetch_sync(self.aq.query_region,
                                        catalog,
@@ -134,8 +141,8 @@ class Heasarc:
 
     def query_object(self, object_name, catalog=None,
                      radius=None, refresh_rate=None,
-                     refresh=False, local=False,
-                     spatial='cone', width=None, polygon=None,
+                     mode='standard', spatial='cone',
+                     width=None, polygon=None,
                      **kwargs) -> pd.DataFrame:
         """
         Queries a catalog at the heasarc for records around a specific
@@ -152,17 +159,18 @@ class Heasarc:
         refresh_rate: int or None, default = None, optional,
                       time in days before the query should be refreshed
 
-        refresh: bool, default = False, optional
-                 Toggles call to the heasarc to refresh the query response
-                 if True
-
-        local: bool, default = False
-               If True, query the local database directly for the specified
-               spatial region instead of fetching from the remote heasarc.
+        mode: str, default 'standard'
+              Query mode. ``'standard'`` checks local cache first and
+              fetches from remote if no cached data exists.
+              ``'refresh'`` always fetches from remote and updates the
+              cache. ``'local'`` queries the local database directly for
+              the specified spatial region, bypassing remote calls and
+              query history lookup.
 
         spatial: str, default 'cone'
                  Type of spatial query for local mode: 'cone', 'box',
-                 'polygon', or 'all-sky'. Ignored if local is False.
+                 'polygon', or 'all-sky'. Ignored if mode is not
+                 ``'local'``.
 
         width: str or `~astropy.units.Quantity`, optional
                Width of the box search region for local mode.
@@ -179,8 +187,7 @@ class Heasarc:
                                  catalog=catalog,
                                  radius=radius,
                                  refresh_rate=refresh_rate,
-                                 refresh=refresh,
-                                 local=local,
+                                 mode=mode,
                                  spatial=spatial,
                                  width=width,
                                  polygon=polygon,

--- a/astrostash/heasarc/tests/test_heasarc.py
+++ b/astrostash/heasarc/tests/test_heasarc.py
@@ -102,7 +102,7 @@ def test_download_data(copy_dir_setup):
     sel = products.loc[products["rowid"] == "43555"]
     heasarc.download_data(sel, "nicermastr", host="heasarc", location=".")
     local_paths = heasarc.ldb.get_local_data_paths_by_catalog("nicermastr")
-    expected_dir = str(pl.Path(f"./1013010107").resolve())
+    expected_dir = str(pl.Path("./1013010107").resolve())
     dummy_frame = pd.DataFrame({
         "id": [1],
         "catalog": ["nicermastr"],
@@ -116,7 +116,7 @@ def test_download_data(copy_dir_setup):
 def test_query_region_local_cone(setup):
     pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
     result = setup.query_region(position=pos, catalog='nicermastr',
-                                radius='0.5deg', local=True)
+                                radius='0.5deg', mode='local')
     assert not result.empty
     assert len(result) == 188
     assert 'ra' in result.columns
@@ -128,44 +128,44 @@ def test_query_region_local_cone_quantity(setup):
     from astropy import units as u
     pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
     result = setup.query_region(position=pos, catalog='nicermastr',
-                                radius=0.5 * u.deg, local=True)
+                                radius=0.5 * u.deg, mode='local')
     assert not result.empty
     assert len(result) == 188
 
 
 def test_query_region_local_allsky(setup):
     result = setup.query_region(catalog='uhuru4',
-                                spatial='all-sky', local=True)
+                                spatial='all-sky', mode='local')
     assert len(result) == 339
 
 
 def test_query_region_local_no_catalog(setup):
     with pytest.raises(ValueError, match="catalog is required"):
-        setup.query_region(local=True, position='10d 20d', radius='1deg')
+        setup.query_region(mode='local', position='10d 20d', radius='1deg')
 
 
 def test_query_region_local_no_table(setup):
     with pytest.raises(ValueError, match="does not exist"):
-        setup.query_region(catalog='nonexistent', local=True,
+        setup.query_region(catalog='nonexistent', mode='local',
                            spatial='all-sky')
 
 
 def test_query_region_local_missing_position(setup):
     with pytest.raises(ValueError, match="position is required"):
-        setup.query_region(catalog='nicermastr', local=True,
+        setup.query_region(catalog='nicermastr', mode='local',
                            radius='1deg')
 
 
 def test_query_region_local_missing_radius(setup):
     pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
     with pytest.raises(ValueError, match="radius is required"):
-        setup.query_region(position=pos, catalog='nicermastr', local=True)
+        setup.query_region(position=pos, catalog='nicermastr', mode='local')
 
 
 def test_query_region_local_box(setup):
     pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
     result = setup.query_region(position=pos, catalog='nicermastr',
-                                spatial='box', width='0.01deg', local=True)
+                                spatial='box', width='0.01deg', mode='local')
     assert not result.empty
     # All results should be within the box
     assert all(result['ra'] >= 83.633 - 0.005)
@@ -178,13 +178,14 @@ def test_query_region_local_box_missing_width(setup):
     pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
     with pytest.raises(ValueError, match="width is required"):
         setup.query_region(position=pos, catalog='nicermastr',
-                           spatial='box', local=True)
+                           spatial='box', mode='local')
 
 
 def test_query_region_local_polygon(setup):
     verts = [(83.62, 22.01), (83.65, 22.01), (83.65, 22.03), (83.62, 22.03)]
     result = setup.query_region(catalog='nicermastr',
-                                spatial='polygon', polygon=verts, local=True)
+                                spatial='polygon',
+                                polygon=verts, mode='local')
     assert not result.empty
     # All results should be within the polygon bounds
     assert all(result['ra'] >= 83.62)
@@ -196,17 +197,24 @@ def test_query_region_local_polygon(setup):
 def test_query_region_local_polygon_missing_polygon(setup):
     with pytest.raises(ValueError, match="polygon is required"):
         setup.query_region(catalog='nicermastr',
-                           spatial='polygon', local=True)
+                           spatial='polygon', mode='local')
 
 
 def test_query_region_local_unknown_spatial(setup):
     with pytest.raises(ValueError, match="Unknown spatial mode"):
         setup.query_region(catalog='nicermastr',
-                           spatial='invalid', local=True)
+                           spatial='invalid', mode='local')
 
 
 def test_query_region_local_no_ra_dec(setup):
     # heasarc_catalog_list has no ra/dec columns
     with pytest.raises(ValueError, match="has no 'ra' and 'dec' columns"):
         setup.query_region(catalog='heasarc_catalog_list',
-                           spatial='all-sky', local=True)
+                           spatial='all-sky', mode='local')
+
+
+def test_query_region_invalid_mode(setup):
+    pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
+    with pytest.raises(ValueError, match="Unknown mode"):
+        setup.query_region(position=pos, catalog='nicermastr',
+                           radius='0.5deg', mode='bogus')

--- a/astrostash/heasarc/tests/test_heasarc.py
+++ b/astrostash/heasarc/tests/test_heasarc.py
@@ -111,3 +111,102 @@ def test_download_data(copy_dir_setup):
     })
     pd.testing.assert_frame_equal(local_paths, dummy_frame)
     shutil.rmtree(expected_dir)
+
+
+def test_query_region_local_cone(setup):
+    pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
+    result = setup.query_region(position=pos, catalog='nicermastr',
+                                radius='0.5deg', local=True)
+    assert not result.empty
+    assert len(result) == 188
+    assert 'ra' in result.columns
+    assert 'dec' in result.columns
+    assert 'name' in result.columns
+
+
+def test_query_region_local_cone_quantity(setup):
+    from astropy import units as u
+    pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
+    result = setup.query_region(position=pos, catalog='nicermastr',
+                                radius=0.5 * u.deg, local=True)
+    assert not result.empty
+    assert len(result) == 188
+
+
+def test_query_region_local_allsky(setup):
+    result = setup.query_region(catalog='uhuru4',
+                                spatial='all-sky', local=True)
+    assert len(result) == 339
+
+
+def test_query_region_local_no_catalog(setup):
+    with pytest.raises(ValueError, match="catalog is required"):
+        setup.query_region(local=True, position='10d 20d', radius='1deg')
+
+
+def test_query_region_local_no_table(setup):
+    with pytest.raises(ValueError, match="does not exist"):
+        setup.query_region(catalog='nonexistent', local=True,
+                           spatial='all-sky')
+
+
+def test_query_region_local_missing_position(setup):
+    with pytest.raises(ValueError, match="position is required"):
+        setup.query_region(catalog='nicermastr', local=True,
+                           radius='1deg')
+
+
+def test_query_region_local_missing_radius(setup):
+    pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
+    with pytest.raises(ValueError, match="radius is required"):
+        setup.query_region(position=pos, catalog='nicermastr', local=True)
+
+
+def test_query_region_local_box(setup):
+    pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
+    result = setup.query_region(position=pos, catalog='nicermastr',
+                                spatial='box', width='0.01deg', local=True)
+    assert not result.empty
+    # All results should be within the box
+    assert all(result['ra'] >= 83.633 - 0.005)
+    assert all(result['ra'] <= 83.633 + 0.005)
+    assert all(result['dec'] >= 22.015 - 0.005)
+    assert all(result['dec'] <= 22.015 + 0.005)
+
+
+def test_query_region_local_box_missing_width(setup):
+    pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
+    with pytest.raises(ValueError, match="width is required"):
+        setup.query_region(position=pos, catalog='nicermastr',
+                           spatial='box', local=True)
+
+
+def test_query_region_local_polygon(setup):
+    verts = [(83.62, 22.01), (83.65, 22.01), (83.65, 22.03), (83.62, 22.03)]
+    result = setup.query_region(catalog='nicermastr',
+                                spatial='polygon', polygon=verts, local=True)
+    assert not result.empty
+    # All results should be within the polygon bounds
+    assert all(result['ra'] >= 83.62)
+    assert all(result['ra'] <= 83.65)
+    assert all(result['dec'] >= 22.01)
+    assert all(result['dec'] <= 22.03)
+
+
+def test_query_region_local_polygon_missing_polygon(setup):
+    with pytest.raises(ValueError, match="polygon is required"):
+        setup.query_region(catalog='nicermastr',
+                           spatial='polygon', local=True)
+
+
+def test_query_region_local_unknown_spatial(setup):
+    with pytest.raises(ValueError, match="Unknown spatial mode"):
+        setup.query_region(catalog='nicermastr',
+                           spatial='invalid', local=True)
+
+
+def test_query_region_local_no_ra_dec(setup):
+    # heasarc_catalog_list has no ra/dec columns
+    with pytest.raises(ValueError, match="has no 'ra' and 'dec' columns"):
+        setup.query_region(catalog='heasarc_catalog_list',
+                           spatial='all-sky', local=True)

--- a/astrostash/tests/test_astrostash_core.py
+++ b/astrostash/tests/test_astrostash_core.py
@@ -6,6 +6,7 @@ import pytest
 import pandas as pd
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
+from astropy import units as u
 from unittest.mock import MagicMock
 
 
@@ -186,3 +187,141 @@ def test_insert_local_data_path(setup_sqlite_db):
         "location": [demo_product_path]
     })
     pd.testing.assert_frame_equal(local_data_frame, dummy_frame)
+
+
+@pytest.fixture
+def setup_spatial_db(setup_sqlite_db):
+    sql, db_path = setup_sqlite_db
+    df = pd.DataFrame({
+        'ra': [10.0, 10.1, 10.5, 20.0, 150.0],
+        'dec': [20.0, 20.1, 20.5, 30.0, -45.0],
+        'name': ['a', 'b', 'c', 'd', 'e'],
+        '__row': ['1', '2', '3', '4', '5']
+    })
+    sql.ingest_table(df, 'test_cat')
+    return sql
+
+
+def test_query_region_cone(setup_spatial_db):
+    sql = setup_spatial_db
+    center = SkyCoord(ra=10.0, dec=20.0, unit='deg')
+    result = sql.query_region('test_cat', position=center,
+                              spatial='cone', radius='0.2deg')
+    assert len(result) == 2
+    names = sorted(result['name'].tolist())
+    assert names == ['a', 'b']
+
+
+def test_query_region_cone_with_quantity(setup_spatial_db):
+    sql = setup_spatial_db
+    center = SkyCoord(ra=10.0, dec=20.0, unit='deg')
+    result = sql.query_region('test_cat', position=center,
+                              spatial='cone', radius=0.2 * u.deg)
+    assert len(result) == 2
+    names = sorted(result['name'].tolist())
+    assert names == ['a', 'b']
+
+
+def test_query_region_cone_string_position(setup_spatial_db):
+    sql = setup_spatial_db
+    result = sql.query_region('test_cat', position='10d 20d',
+                              spatial='cone', radius='0.2deg')
+    assert len(result) == 2
+    names = sorted(result['name'].tolist())
+    assert names == ['a', 'b']
+
+
+def test_query_region_box(setup_spatial_db):
+    sql = setup_spatial_db
+    center = SkyCoord(ra=10.0, dec=20.0, unit='deg')
+    result = sql.query_region('test_cat', position=center,
+                              spatial='box', width='0.3deg')
+    assert len(result) == 2
+    names = sorted(result['name'].tolist())
+    assert names == ['a', 'b']
+
+
+def test_query_region_box_with_quantity(setup_spatial_db):
+    sql = setup_spatial_db
+    center = SkyCoord(ra=10.0, dec=20.0, unit='deg')
+    result = sql.query_region('test_cat', position=center,
+                              spatial='box', width=0.3 * u.deg)
+    assert len(result) == 2
+    names = sorted(result['name'].tolist())
+    assert names == ['a', 'b']
+
+
+def test_query_region_polygon(setup_spatial_db):
+    sql = setup_spatial_db
+    verts = [(9.8, 19.8), (10.3, 19.8), (10.3, 20.3), (9.8, 20.3)]
+    result = sql.query_region('test_cat', spatial='polygon', polygon=verts)
+    assert len(result) == 2
+    names = sorted(result['name'].tolist())
+    assert names == ['a', 'b']
+
+
+def test_query_region_allsky(setup_spatial_db):
+    sql = setup_spatial_db
+    result = sql.query_region('test_cat', spatial='all-sky')
+    assert len(result) == 5
+
+
+def test_query_region_empty_table(setup_sqlite_db):
+    sql, db_path = setup_sqlite_db
+    df = pd.DataFrame({
+        'ra': pd.Series(dtype='float64'),
+        'dec': pd.Series(dtype='float64'),
+        'name': pd.Series(dtype='object'),
+        '__row': pd.Series(dtype='object')
+    })
+    sql.ingest_table(df, 'empty_cat')
+    center = SkyCoord(ra=10.0, dec=20.0, unit='deg')
+    result = sql.query_region('empty_cat', position=center,
+                              spatial='cone', radius='1deg')
+    assert result.empty
+
+
+def test_query_region_no_table(setup_spatial_db):
+    sql = setup_spatial_db
+    with pytest.raises(ValueError, match="does not exist"):
+        sql.query_region('nonexistent', spatial='all-sky')
+
+
+def test_query_region_no_ra_dec(setup_sqlite_db):
+    sql, db_path = setup_sqlite_db
+    df = pd.DataFrame({'x': [1, 2], 'y': [3, 4]})
+    sql.ingest_table(df, 'no_radec')
+    with pytest.raises(ValueError, match="has no 'ra' and 'dec' columns"):
+        sql.query_region('no_radec', spatial='all-sky')
+
+
+def test_query_region_missing_position(setup_spatial_db):
+    sql = setup_spatial_db
+    with pytest.raises(ValueError, match="position is required"):
+        sql.query_region('test_cat', spatial='cone', radius='1deg')
+
+
+def test_query_region_missing_radius(setup_spatial_db):
+    sql = setup_spatial_db
+    center = SkyCoord(ra=10.0, dec=20.0, unit='deg')
+    with pytest.raises(ValueError, match="radius is required"):
+        sql.query_region('test_cat', position=center, spatial='cone')
+
+
+def test_query_region_missing_width(setup_spatial_db):
+    sql = setup_spatial_db
+    center = SkyCoord(ra=10.0, dec=20.0, unit='deg')
+    with pytest.raises(ValueError, match="width is required"):
+        sql.query_region('test_cat', position=center, spatial='box')
+
+
+def test_query_region_missing_polygon(setup_spatial_db):
+    sql = setup_spatial_db
+    with pytest.raises(ValueError, match="polygon is required"):
+        sql.query_region('test_cat', spatial='polygon')
+
+
+def test_query_region_unknown_spatial(setup_spatial_db):
+    sql = setup_spatial_db
+    with pytest.raises(ValueError, match="Unknown spatial mode"):
+        sql.query_region('test_cat', spatial='invalid')


### PR DESCRIPTION
This PR adds in functionality to query existing data in a sqlite astrostash database locally for queries that do not have established links. This is necessary since astrostash previously relied on making external connections to the remote data source to pull data that may have already existed in the database, just for the purpose of establishing query-response row links. 

In order to accomplish this, first, `SQLiteDB.query_region` was created as a basic region querying analog to allow astronomical region querying that could be easily supported with sqlite and pandas since using ADQL's isn't an option with sqlite. In addition to this function creation numerous helper functions were created.

Then local querying functionality using `Heasarc.query_region` and `Heasarc.query_object` was applied using the newly created function. Keep in mind that this new functionality doesn't store any query-response links. It just does pandas filtering of the local data table.

In addition to this the ``refresh`` kwarg was removed for the previously mentioned heasarc functions in favor of the ``mode`` kwarg that has 3 modes: standard, refresh, and local. Local queries locally data only. Refresh queries remotely only to refresh the database, and standard checks the cached data first and if it exists, returns it, if not it queries remotely.