### PR TITLE
Created Heasarc docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# v0.2.0
+
+## New Features
+- Local spatial queries via `SQLiteDB.query_region` (cone, box, polygon, all-sky)
+- `mode` kwarg for `Heasarc.query_region` and `Heasarc.query_object` (standard / refresh / local)
+- `Heasarc.locate_data()` — find download links for data products
+- `Heasarc.download_data()` — download data products and track local paths
+- `local_data_paths` table for tracking downloaded data products
+- Local mirroring workflow — stash entire tables via `query_tap`, query offline with `mode='local'`
+
+## Improvements
+- NumPy-style docstrings across all public methods
+- Bulk inserts for response row ID pivots
+- Refactored dict operations (`del` → `pop`)
+
+## Documentation
+- New `docs/heasarc.md` — architecture, quickstart, local mirroring, API reference
+- Overhauled README with Documentation section and links
+
 # v0.1.1
 
 - Removed f-string queries from Heasarc #13

--- a/README.md
+++ b/README.md
@@ -1,51 +1,71 @@
 ![GitHub License](https://img.shields.io/github/license/nkphysics/astrostash)
 ![GitHub branch check runs](https://img.shields.io/github/check-runs/nkphysics/astrostash/master)
 
-
 # astrostash
 
-**An astronomy and astrophysics database building/syncing tool**
+🔭 **An astronomy and astrophysics database building/syncing tool**
 
-Astrostash is designed to allow users to "stash" query results from astronomy/astrophysics data sources (e.g., HEASARC) into a local SQLite3 database. This ensures data retention and reduces reliance on external services for recurring queries.
+Astrostash lets you "stash" query results from astronomy data sources into a local SQLite3 database by caching individual queries, or mirroring entire catalog tables for offline access.
+
+---
+
+## Features
+
+- **Local data storage** — Retain copies of query results in a SQLite3 database.
+- **Offline querying** — Mirror stable catalog tables and query them with spatial filters without network access.
+- **Automatic caching** — Results from repeated queries are served from your local database.
+- **Refresh scheduling** — Set a refresh interval to keep cached data up to date.
 
 ---
 
-## 🌟 Features
-
-- **Local data storage**: Retain copies of query results in a SQLite3 database so you can keep your own copy of the data you use and care about having access to.
-- **Efficient querying**: Prioritizes querying from your local database before pulling data externally to limit external requests.
-
----
 ## Requirements
 
-python >= 3.10
+Python >= 3.10
 
 ### 📦 Dependencies
 
-- sqlite3
 - `astroquery >= 0.4.10`
 - `pandas >= 2.3.0`
 - `SQLAlchemy >= 2.0.43`
 
 ---
 
-## 🚧 Current State
+## 📥 Installation
 
-**Version**: `v0.1.1`
-**Status**: Alpha
+```bash
+pip install astrostash
+```
 
-**Supported Archives**: 
+Or clone and install from source:
 
-- HEASARC 
+```bash
+git clone https://github.com/nkphysics/astrostash.git
+cd astrostash
+pip install .
+```
+
+For info on **Getting Started** see the docs linked below.
 
 ---
 
-## 📥 Installation
+## 📚 Documentation
 
-1. Clone the repo
+- **[HEASARC](docs/heasarc.md)** — Quickstart, local mirroring workflow, spatial queries, data products, and full API reference.
 
-2. Run `python -m pip install .`
+---
 
-OR
+## Development
 
-Run `pip install astrostash`
+🚧 Current State: Alpha
+
+Install dev dependencies:
+
+```bash
+pip install .[dev]
+```
+
+---
+
+## License
+
+BSD 3-Clause. See [LICENSE](LICENSE) for details.

--- a/astrostash/heasarc/core.py
+++ b/astrostash/heasarc/core.py
@@ -8,6 +8,15 @@ import pathlib as pl
 
 class Heasarc:
     def __init__(self, db_name=None):
+        """
+        Create a Heasarc instance backed by a local SQLite database.
+
+        Parameters
+        ----------
+        db_name : str or None, optional
+            Path to the SQLite database file. If None, the default
+            astrostash database location is used.
+        """
         self.aq = astroquery.heasarc.Heasarc()
         self.ldb = SQLiteDB(db_name=db_name)
 
@@ -17,25 +26,27 @@ class Heasarc:
                       refresh_rate=None,
                       refresh=False) -> pd.DataFrame:
         """
-        Gets a DataFrame of all available catalogs in the form of
-        (name, description)
+        Get a DataFrame of all available HEASARC catalogs.
 
-        Parameters:
-        master: bool, Gets only master catalogs if True, default False
+        Parameters
+        ----------
+        master : bool, optional
+            If True, return only master catalogs. Default is False.
+        keywords : str or list of str, optional
+            Search terms for filtering catalogs. Words in a string
+            separated by spaces are AND'ed, while words in a list
+            are OR'ed.
+        refresh_rate : int or None, optional
+            Time in days before the query should be refreshed.
+            Default is None.
+        refresh : bool, optional
+            If True, force a remote fetch to refresh the catalog list.
+            Default is False.
 
-        keywords: str or list, keywords used as search terms for catalogs.
-                               Words with a str separated by a space
-                               are AND'ed, while words in a list are OR'ed
-
-        refresh_rate: int or None, default = None,
-                      time in days before the query should be refreshed
-
-        refresh: bool, default = False
-                 Toggles call to the heasarc to refresh the table names
-                 response if True
-
-        Returns:
-        pd.DataFrame, heasarc catalogs and descriptions
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with columns ``name`` and ``description``.
         """
         params = locals().copy()
         params.pop("self", None)
@@ -48,13 +59,17 @@ class Heasarc:
 
     def _check_catalog_exists(self, catalog: str) -> bool:
         """
-        Checks whether or not a catalog exists at the heasarc
+        Check whether a catalog exists at the HEASARC.
 
-        Parameters:
-        catalog: str, name of catalog
+        Parameters
+        ----------
+        catalog : str
+            Name of the catalog to check.
 
-        Returns:
-        bool, True if catalog exists at the heasarc otherwise false
+        Returns
+        -------
+        bool
+            True if the catalog exists at the HEASARC, False otherwise.
         """
         catalogs = self.list_catalogs()["name"].values
         return catalog in catalogs
@@ -65,49 +80,47 @@ class Heasarc:
                      width=None, polygon=None,
                      **kwargs) -> pd.DataFrame:
         """
-        Queries a catalog at the heasarc for records around a specific
-        region
+        Query a HEASARC catalog for records around a specific region.
 
-        Parameters:
-        position: str, `astropy.coordinates` object with coordinate positions
-                        Required if spatial is cone or box.
-                        Ignored if spatial is polygon or all-sky.
+        Parameters
+        ----------
+        position : str or `~astropy.coordinates.SkyCoord`, optional
+            Coordinate position for the query. Required if ``spatial``
+            is ``'cone'`` or ``'box'``. Ignored if ``spatial`` is
+            ``'polygon'`` or ``'all-sky'``.
+        catalog : str
+            Catalog name as listed at the HEASARC.
+        radius : str or `~astropy.units.Quantity`, optional
+            Search radius for cone queries.
+        refresh_rate : int or None, optional
+            Time in days before the query should be refreshed.
+            Default is None.
+        mode : str, optional
+            Query mode. ``'standard'`` checks local cache first and
+            fetches from remote if no cached data exists. ``'refresh'``
+            always fetches from remote and updates the cache. ``'local'``
+            queries the local database directly for the specified spatial
+            region, bypassing remote calls and query history lookup.
+            Default is ``'standard'``.
+        spatial : str, optional
+            Type of spatial query for local mode: ``'cone'``, ``'box'``,
+            ``'polygon'``, or ``'all-sky'``. Ignored if ``mode`` is not
+            ``'local'``. Default is ``'cone'``.
+        width : str or `~astropy.units.Quantity`, optional
+            Width of the box search region. Required when ``spatial``
+            is ``'box'`` in local mode.
+        polygon : list of tuple, optional
+            List of ``(ra, dec)`` pairs in decimal degrees outlining the
+            polygon to search. Required when ``spatial`` is ``'polygon'``
+            in local mode.
+        **kwargs
+            Additional keyword arguments passed to the underlying
+            HEASARC query method.
 
-        catalog: str, catalog name as listed at the heasarc
-
-        radius: str or `~astropy.units.Quantity`,
-                search radius
-
-        refresh_rate: int or None, default = None,
-                      time in days before the query should be refreshed
-
-        mode: str, default 'standard'
-              Query mode. ``'standard'`` checks local cache first and
-              fetches from remote if no cached data exists.
-              ``'refresh'`` always fetches from remote and updates the
-              cache. ``'local'`` queries the local database directly for
-              the specified spatial region, bypassing remote calls and
-              query history lookup.
-
-        spatial: str, default 'cone'
-                 Type of spatial query for local mode: 'cone', 'box',
-                 'polygon', or 'all-sky'. Ignored if mode is not
-                 ``'local'``.
-
-        width: str or `~astropy.units.Quantity`, [Required for
-               spatial == ``'box'`` in local mode]
-               Width of the box search region.
-
-        polygon: list, [Required for spatial is ``'polygon'`` in local
-                 mode]
-                 A list of ``(ra, dec)`` pairs in decimal degrees
-                 outlining the polygon to search in.
-
-        **kwargs: additional kwargs to be passed into
-                   astroquery.Heasarc.query_region
-
-        Returns:
-        pd.DataFrame, table of catalog's records around the specified region
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame of catalog records around the specified region.
         """
         if mode == 'local':
             if catalog is None:
@@ -145,42 +158,41 @@ class Heasarc:
                      width=None, polygon=None,
                      **kwargs) -> pd.DataFrame:
         """
-        Queries a catalog at the heasarc for records around a specific
-        object/source
+        Query a HEASARC catalog for records around a specific object.
 
-        Parameters:
-        object_name: str, object name (e.x. PSR B0531+21)
+        Resolves the object name to coordinates using
+        `~astropy.coordinates.SkyCoord.from_name`, then delegates to
+        `query_region`.
 
-        catalog: str, optional, catalog name as listed at the heasarc
+        Parameters
+        ----------
+        object_name : str
+            Name of the astronomical object (e.g. ``'PSR B0531+21'``).
+        catalog : str, optional
+            Catalog name as listed at the HEASARC.
+        radius : str or `~astropy.units.Quantity`, optional
+            Search radius for the query.
+        refresh_rate : int or None, optional
+            Time in days before the query should be refreshed.
+            Default is None.
+        mode : str, optional
+            Query mode: ``'standard'``, ``'refresh'``, or ``'local'``.
+            See `query_region` for details. Default is ``'standard'``.
+        spatial : str, optional
+            Spatial query type for local mode: ``'cone'``, ``'box'``,
+            ``'polygon'``, or ``'all-sky'``. Default is ``'cone'``.
+        width : str or `~astropy.units.Quantity`, optional
+            Width of the box search region for local mode.
+        polygon : list of tuple, optional
+            List of ``(ra, dec)`` pairs in decimal degrees for polygon
+            queries in local mode.
+        **kwargs
+            Additional keyword arguments passed to `query_region`.
 
-        radius: str or `~astropy.units.Quantity`, optional
-                search radius
-
-        refresh_rate: int or None, default = None, optional,
-                      time in days before the query should be refreshed
-
-        mode: str, default 'standard'
-              Query mode. ``'standard'`` checks local cache first and
-              fetches from remote if no cached data exists.
-              ``'refresh'`` always fetches from remote and updates the
-              cache. ``'local'`` queries the local database directly for
-              the specified spatial region, bypassing remote calls and
-              query history lookup.
-
-        spatial: str, default 'cone'
-                 Type of spatial query for local mode: 'cone', 'box',
-                 'polygon', or 'all-sky'. Ignored if mode is not
-                 ``'local'``.
-
-        width: str or `~astropy.units.Quantity`, optional
-               Width of the box search region for local mode.
-
-        polygon: list, optional
-                 A list of (ra, dec) pairs in decimal degrees outlining
-                 the polygon to search in for local mode.
-
-        Returns:
-        pd.DataFrame, table of catalog's records for the specified object
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame of catalog records for the specified object.
         """
         pos = SkyCoord.from_name(object_name)
         return self.query_region(position=pos,
@@ -196,18 +208,28 @@ class Heasarc:
     def query_tap(self, query: str, catalog: str, maxrec=None,
                   refresh_rate=None, refresh=False) -> pd.DataFrame:
         """
-        Queries the HEASARC's Xamin TAP using ADQL
+        Query the HEASARC Xamin TAP service using ADQL.
 
-        Parameters:
-        query: str, ADQL query
+        Parameters
+        ----------
+        query : str
+            ADQL query string.
+        catalog : str
+            Catalog table name to stash the results to.
+        maxrec : int or None, optional
+            Maximum number of records to return. Default is None
+            (server default).
+        refresh_rate : int or None, optional
+            Time in days before the query should be refreshed.
+            Default is None.
+        refresh : bool, optional
+            If True, force a remote fetch to refresh the results.
+            Default is False.
 
-        catalog: str, catalog table name to stash the data to
-
-        maxrec : int or None (default), optional,
-                 maximum number of records to return
-
-        Returns:
-        pd.DataFrame, response from HEASARC for the ADQL query
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame containing the response from the HEASARC.
         """
         params = locals().copy()
         params.pop("self", None)
@@ -223,18 +245,24 @@ class Heasarc:
                     result_table: pd.DataFrame,
                     catalog: str) -> pd.DataFrame:
         """
-        Gets links and local paths to heasarc data products
+        Get download links and local paths to HEASARC data products.
+
+        Merges remote data product locations with any previously
+        downloaded local paths stored in the database.
 
         Parameters
         ----------
-        result_table: pd.DataFrame, results of a previous region, object, or
-                                    tap query
+        result_table : pd.DataFrame
+            Results from a previous `query_region`, `query_object`,
+            or `query_tap` call.
+        catalog : str
+            Name of the catalog the results came from.
 
-        catalog: str, catalog name
-
-        Returns:
-        pd.DataFrame, all relevant links and paths to access heasarc
-                      data products
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame containing download links and local paths
+            for the data products.
         """
         aq_table = Table.from_pandas(result_table)
         remote_df = self.aq.locate_data(aq_table, catalog).to_pandas()
@@ -249,22 +277,25 @@ class Heasarc:
     def download_data(self, links: pd.DataFrame, catalog: str, *,
                       host="aws", location="."):
         """
-        Downloads data from from using the links from the specified host
-        to the location specified, and adds the full path to the data product
-        to the local_data_paths table
+        Download data products from a specified host.
+
+        Downloads files using the links from the given host, saves them
+        to the specified local directory, and records the paths in the
+        local_data_paths table.
 
         Parameters
         ----------
-        links: pd.DataFrame, dataframe with links
-
-        catalog: str, catalog the links come from
-
-        host: str, optional, host to retrieve the data products from
-                             options are aws (default and fastest) sciserver,
-                             or heasarc
-
-        location str, optional, path of the location to download the data to
-                                (default is ".")
+        links : pd.DataFrame
+            DataFrame containing download links (from `locate_data`).
+        catalog : str
+            Name of the catalog the links come from.
+        host : str, optional
+            Host to retrieve data products from. Options are
+            ``'aws'`` (default, fastest), ``'sciserver'``, or
+            ``'heasarc'``.
+        location : str, optional
+            Local directory path to download data to. Default is
+            the current directory (``'.'``).
         """
         links = Table.from_pandas(links)
         linkcol = host

--- a/docs/heasarc.md
+++ b/docs/heasarc.md
@@ -1,0 +1,307 @@
+# astrostash.heasarc
+
+## Quickstart
+
+```python
+from astrostash.heasarc import Heasarc
+from astropy.coordinates import SkyCoord
+
+h = Heasarc()
+
+# List available catalogs (cached after first call)
+catalogs = h.list_catalogs()
+print(catalogs[catalogs["name"].str.contains("nicer")])
+
+# Query a catalog by region
+pos = SkyCoord.from_name("ngc 3783")
+results = h.query_region(position=pos, catalog="nicermastr",
+                         radius="0.5deg", refresh_rate=30)
+print(results)
+
+# Query by object name (resolves coordinates via CDS/Sesame)
+crab = h.query_object("crab", catalog="nicermastr")
+```
+
+On the first call, results are fetched from the HEASARC and stored locally.
+Subsequent calls with the same parameters return the cached results. If a
+`refresh_rate` (in days) is set, results are re-fetched automatically when
+the cache expires.
+
+---
+
+## Architecture & Concepts
+
+### Caching Model
+
+astrostash uses a two-layer caching scheme:
+
+1. **Query tracking** — Each unique set of query parameters is hashed with
+   SHA-256. The hash is stored in the `queries` table along with the date it
+   was last executed and an optional refresh rate.
+
+2. **Response storage** — Query results are stored as named data tables in the
+   same SQLite database (e.g., a table called `nicermastr`). The `responses`
+   table tracks the hash of each result set, and pivot tables link queries to
+   their responses and to individual row IDs.
+
+This means:
+- Identical queries (same parameters) reuse cached results automatically.
+- Different queries against the same catalog share a single data table,
+  with pivot tables tracking which rows belong to which query.
+- The database is self-contained — it can be copied, backed up, or shared
+  as a single `.db` file.
+
+### Query Modes
+
+The `query_region` and `query_object` methods accept a `mode` parameter:
+
+| Mode | Behavior |
+|------|----------|
+| `'standard'` (default) | Check local cache first. If no cached data exists (or if the refresh interval has elapsed), fetch from the HEASARC and update the cache. |
+| `'refresh'` | Always fetch from the HEASARC, regardless of cache state. Updates the cache with fresh results. |
+| `'local'` | Query the local database only. No remote requests are made. Supports spatial filtering (see below). |
+
+### Local Mirroring
+
+Beyond caching repeated queries, astrostash can be used to build a complete
+local mirror of a HEASARC catalog. This is useful for stable, historical or legacy
+tables (e.g., `uhuru4`, `ariel5`) that will (very likely) not change.
+Once stashed, they can be queried entirely offline.
+
+The workflow is two steps:
+
+1. **Stash the table** — Pull the entire catalog into your local database
+   using `query_tap`. This is a one-time operation for stable tables.
+
+2. **Query locally** — Use `query_region` or `query_object` with
+   `mode='local'` to search the stashed data with spatial filters. No
+   network connection is needed.
+
+```python
+from astrostash.heasarc import Heasarc
+from astropy.coordinates import SkyCoord
+
+h = Heasarc("my_data.db")
+
+# Step 1: Stash the entire table (one-time, requires network)
+h.query_tap("SELECT * FROM uhuru4", catalog="uhuru4")
+
+# Step 2: Query locally — no network needed
+pos = SkyCoord(ra=10.0, dec=20.0, unit="deg")
+results = h.query_region(position=pos, catalog="uhuru4",
+                         radius="1deg", mode="local")
+print(len(results))
+
+# All spatial types work in local mode
+all_sky = h.query_region(catalog="uhuru4", spatial="all-sky", mode="local")
+```
+
+The key difference from caching:
+
+- **Caching** (`mode='standard'`) — Stores the results of a specific query
+  so the same query doesn't need to hit HEASARC again. The data is tied to
+  that query's parameters.
+- **Mirroring** (`query_tap` + `mode='local'`) — Stores the entire table.
+  You can then run any spatial query against it locally, without any
+  dependence on the HEASARC service.
+
+### Spatial Queries (Local Mode)
+
+In `'local'` mode, `query_region` filters catalog data by spatial region.
+The table must have `ra` and `dec` columns. Supported spatial types:
+
+| Spatial | Required Parameters | Description |
+|---------|--------------------|-------------|
+| `'cone'` | `position`, `radius` | Circular search around a center point |
+| `'box'` | `position`, `width` | Square box centered on a position |
+| `'polygon'` | `polygon` | Arbitrary polygon defined by `(ra, dec)` pairs in decimal degrees |
+| `'all-sky'` | *(none)* | Returns all cached rows |
+
+Example — local cone query:
+
+```python
+from astropy.coordinates import SkyCoord
+
+h = Heasarc("my_data.db")
+pos = SkyCoord(ra=83.633, dec=22.015, unit="deg")
+results = h.query_region(position=pos, catalog="nicermastr",
+                         radius="0.5deg", mode="local")
+```
+
+### Data Products
+
+After querying a catalog, you can locate and download associated data
+products:
+
+```python
+# Locate available data products for query results
+crab = h.query_object("crab", catalog="nicermastr")
+products = h.locate_data(crab, "nicermastr")
+print(products[["rowid", "aws"]])
+
+# Download from the fastest host (AWS by default)
+to_download = products[products["rowid"] == "43555"]
+h.download_data(to_download, "nicermastr", location="./data")
+```
+
+`locate_data` returns a DataFrame with download links (AWS, SciServer,
+HEASARC) and any previously recorded local paths. `download_data` fetches
+files and records their local paths in the database for future reference.
+
+---
+
+## API Reference
+
+### `Heasarc`
+
+```python
+Heasarc(db_name=None)
+```
+
+Create a HEASARC client backed by a local SQLite database.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `db_name` | `str` or `None` | Path to the SQLite database file. Defaults to `astrostash.db` in the current directory. |
+
+---
+
+#### `list_catalogs`
+
+```python
+list_catalogs(*, master=False, keywords=None,
+              refresh_rate=None, refresh=False) -> pd.DataFrame
+```
+
+Get all available HEASARC catalogs.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `master` | `bool` | `False` | Return only master catalogs |
+| `keywords` | `str` or `list[str]` | `None` | Filter catalogs by keyword(s). Strings are space-AND'ed, lists are OR'ed |
+| `refresh_rate` | `int` or `None` | `None` | Cache refresh interval in days |
+| `refresh` | `bool` | `False` | Force remote fetch |
+
+**Returns:** `pd.DataFrame` with columns `name` and `description`.
+
+---
+
+#### `query_region`
+
+```python
+query_region(position=None, catalog=None, radius=None,
+             refresh_rate=None, mode='standard', spatial='cone',
+             width=None, polygon=None, **kwargs) -> pd.DataFrame
+```
+
+Query a HEASARC catalog for records around a specific region.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `position` | `str` or `SkyCoord` | `None` | Center position. Required for `cone`/`box`. Ignored for `polygon`/`all-sky` |
+| `catalog` | `str` | `None` | Catalog name as listed at the HEASARC |
+| `radius` | `str` or `Quantity` | `None` | Search radius for cone queries |
+| `refresh_rate` | `int` or `None` | `None` | Cache refresh interval in days |
+| `mode` | `str` | `'standard'` | `'standard'`, `'refresh'`, or `'local'` |
+| `spatial` | `str` | `'cone'` | Local mode spatial type: `'cone'`, `'box'`, `'polygon'`, or `'all-sky'` |
+| `width` | `str` or `Quantity` | `None` | Width for box queries (local mode) |
+| `polygon` | `list[tuple]` | `None` | `(ra, dec)` pairs in degrees for polygon queries (local mode) |
+| `**kwargs` | | | Passed to the underlying HEASARC query method |
+
+**Returns:** `pd.DataFrame` of catalog records.
+
+---
+
+#### `query_object`
+
+```python
+query_object(object_name, catalog=None, radius=None,
+             refresh_rate=None, mode='standard', spatial='cone',
+             width=None, polygon=None, **kwargs) -> pd.DataFrame
+```
+
+Query a catalog by object name. Resolves coordinates via
+`SkyCoord.from_name`, then delegates to `query_region`.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `object_name` | `str` | | Object name (e.g. `'PSR B0531+21'`) |
+| `catalog` | `str` | `None` | Catalog name |
+| `radius` | `str` or `Quantity` | `None` | Search radius |
+| `refresh_rate` | `int` or `None` | `None` | Cache refresh interval in days |
+| `mode` | `str` | `'standard'` | `'standard'`, `'refresh'`, or `'local'` |
+| `spatial` | `str` | `'cone'` | Local mode spatial type |
+| `width` | `str` or `Quantity` | `None` | Width for box queries (local mode) |
+| `polygon` | `list[tuple]` | `None` | Polygon vertices (local mode) |
+| `**kwargs` | | | Passed to `query_region` |
+
+**Returns:** `pd.DataFrame` of catalog records.
+
+---
+
+#### `query_tap`
+
+```python
+query_tap(query, catalog, maxrec=None,
+          refresh_rate=None, refresh=False) -> pd.DataFrame
+```
+
+Execute an ADQL query against the HEASARC Xamin TAP service.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | `str` | | ADQL query string |
+| `catalog` | `str` | | Catalog table name to stash results to |
+| `maxrec` | `int` or `None` | `None` | Maximum number of records to return |
+| `refresh_rate` | `int` or `None` | `None` | Cache refresh interval in days |
+| `refresh` | `bool` | `False` | Force remote fetch |
+
+**Returns:** `pd.DataFrame` of query results.
+
+---
+
+#### `locate_data`
+
+```python
+locate_data(result_table, catalog) -> pd.DataFrame
+```
+
+Find download links and local paths for data products associated with
+query results.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `result_table` | `pd.DataFrame` | Results from a previous `query_region`, `query_object`, or `query_tap` |
+| `catalog` | `str` | Catalog name |
+
+**Returns:** `pd.DataFrame` with download links (AWS, SciServer, HEASARC)
+and any previously recorded local paths.
+
+---
+
+#### `download_data`
+
+```python
+download_data(links, catalog, *, host="aws", location=".")
+```
+
+Download data products and record their local paths in the database.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `links` | `pd.DataFrame` | | DataFrame with download links (from `locate_data`) |
+| `catalog` | `str` | | Catalog the links belong to |
+| `host` | `str` | `'aws'` | Download host: `'aws'`, `'sciserver'`, or `'heasarc'` |
+| `location` | `str` | `'.'` | Local directory to save files to |
+
+---
+
+## Limitations
+
+- **Alpha status** — API may change between versions.
+- **Remote tests** — Tests marked `@pytest.mark.remote` require network
+  access to HEASARC. By default, `pytest` runs only local/offline tests.
+- **`spatial` parameter** — The `spatial`, `width`, and `polygon` parameters
+  are only used when `mode='local'`. In `'standard'` and `'refresh'` modes,
+  spatial filtering is delegated to the HEASARC service via
+  the underlying HEASARC client.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "astrostash"
-version = "0.1.1"
+version = "0.2.0"
 description = "An astronomy/astrophysics database building and syncing library"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
This PR adds in documentation for the heasarc module, and enhancements to the README related to recent changes/enhancements to the codebase.

## Scope

NumPy-style docstrings, architecture/concepts + usage quickstart for heasarc, and an improved main README. All docs live in-repo (Markdown files).

---

## Standardize Docstrings to NumPy Style

**Files updated**
- `astrostash/heasarc/core.py` — all public methods on `Heasarc`
---

## Add heasarc Documentation (`docs/heasarc.md`)

A standalone Markdown file covering architecture and usage in depth:

```
# astrostash.heasarc

  - The caching model: queries → responses → row pivots
  - SHA-256 hashing for deduplication
  - Refresh scheduling (refresh_rate, last_refreshed)
  - Query modes:
    - standard (cache-first, fetch if miss)
    - refresh (force remote, update cache)
    - local (SQLite-only spatial search)
    - Spatial query types: cone, box, polygon, all-sky
  - Data product workflow: locate → download → local path tracking
  - Mirroring data tables for local querying

## Quickstart
  - Installation
  - Basic query_region example
  - Query by object name
  - Using different modes
  - TAP queries (ADQL)
  - Locating and downloading data products

## API Reference
  - Table summarizing Heasarc methods with signatures + one-line descriptions
  - "See docstrings for full parameter details"

## Limitations & Notes
  - Alpha status
  - Remote tests require network access
```

---

## Add Local Mirroring Section to `docs/heasarc.md`

Add a new subsection explaining the local mirroring/cloning workflow:

- New `### Local Mirroring` subsection under Architecture & Concepts
- Explain the pattern: use `query_tap` to stash an entire table, then query
  it offline with `mode='local'`
- Distinguish from caching: mirroring is about building a complete local copy
  of a stable table, not just caching repeated queries
- Add a quickstart example showing the two-step workflow (stash, then query locally)

---

## Update CHANGELOG.md and Bump Version

- Add v0.2.0 changelog entry covering new features, improvements, and documentation
- Bump `version` in `pyproject.toml` from `0.1.1` to `0.2.0`

