### PR TITLE
Created `Heasarc.stash_full_catalog`

### DIFF
--- a/astrostash/heasarc/core.py
+++ b/astrostash/heasarc/core.py
@@ -1,9 +1,11 @@
+import logging
 import astroquery.heasarc
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astrostash import SQLiteDB
 import pandas as pd
 import pathlib as pl
+import time
 
 
 class Heasarc:
@@ -309,3 +311,45 @@ class Heasarc:
                 catalog,
                 row["rowid"],
                 f"{location}/{download_name}")
+
+    def stash_full_catalog(self, catalog: str,
+                           chunk_size: int = 20000,
+                           max_retries: int = 3) -> None:
+        """
+        Fetch an entire HEASARC catalog and stash it to the local database.
+
+        This method solves the DALOverflowWarning issue that occurs when
+        querying large catalogs with ``SELECT * FROM {catalog}`` by fetching
+        in chunks. After stashing, use ``query_region(..., mode='local')`` for
+        offline queries.
+
+        Parameters
+        ----------
+        catalog : str
+            Catalog table name (e.g., ``'nicermastr'``).
+        chunk_size : int, optional
+            Number of rows per query batch. Default is 20000.
+        """
+        if not self._check_catalog_exists(catalog):
+            raise ValueError(f"Catalog '{catalog}' does not exist at HEASARC")
+        count_result = self.aq.query_tap(
+            f"SELECT COUNT(*) FROM {catalog}").to_table()
+        total_rows = int(count_result['count'][0])
+        for offset in range(0, total_rows, chunk_size):
+            query = (f"SELECT TOP {chunk_size} * FROM {catalog} "
+                     f"OFFSET {offset}")
+            for attempt in range(max_retries):
+                try:
+                    self.query_tap(query, catalog, maxrec=chunk_size,
+                                   refresh=True)
+                    break
+                except (ConnectionError, TimeoutError, OSError) as e:
+                    if attempt == max_retries - 1:
+                        raise RuntimeError(
+                            f"Failed to fetch chunk at offset {offset} "
+                            f"after {max_retries} retries") from e
+                    logging.warning(
+                        f"Attempt {attempt + 1}/{max_retries} failed for "
+                        f"chunk at offset {offset}: {e}. "
+                        f"Retrying in {2 ** attempt} seconds...")
+                    time.sleep(2 ** attempt)

--- a/astrostash/heasarc/tests/test_heasarc.py
+++ b/astrostash/heasarc/tests/test_heasarc.py
@@ -119,6 +119,16 @@ def test_download_data(copy_dir_setup):
     shutil.rmtree(expected_dir)
 
 
+@pytest.mark.remote
+def test_stash_full_catalog():
+    h = Heasarc()
+    h.stash_full_catalog("uhuru4", chunk_size=200)
+    assert h.ldb._check_table_exists("uhuru4")
+    result = h.query_region(catalog="uhuru4", spatial="all-sky", mode="local")
+    assert len(result) == 339
+    os.remove("astrostash.db")
+
+
 def test_query_region_local_cone(setup):
     pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
     result = setup.query_region(position=pos, catalog='nicermastr',

--- a/docs/heasarc.md
+++ b/docs/heasarc.md
@@ -71,7 +71,8 @@ Once stashed, they can be queried entirely offline.
 The workflow is two steps:
 
 1. **Stash the table** — Pull the entire catalog into your local database
-   using `query_tap`. This is a one-time operation for stable tables.
+   using `stash_full_catalog`. This is a one-time operation for stable tables.
+   For smaller or ad-hoc queries, `query_tap` can also be used.
 
 2. **Query locally** — Use `query_region` or `query_object` with
    `mode='local'` to search the stashed data with spatial filters. No
@@ -84,24 +85,28 @@ from astropy.coordinates import SkyCoord
 h = Heasarc("my_data.db")
 
 # Step 1: Stash the entire table (one-time, requires network)
-h.query_tap("SELECT * FROM uhuru4", catalog="uhuru4")
+h.stash_full_catalog("uhuru4")
 
 # Step 2: Query locally — no network needed
 pos = SkyCoord(ra=10.0, dec=20.0, unit="deg")
 results = h.query_region(position=pos, catalog="uhuru4",
                          radius="1deg", mode="local")
-print(len(results))
 
 # All spatial types work in local mode
 all_sky = h.query_region(catalog="uhuru4", spatial="all-sky", mode="local")
 ```
+
+> **Warning:** For large catalogs, avoid using `query_tap` with
+> `SELECT * FROM catalog` — it can trigger `DALOverflowWarning` and
+> fail to return all rows. Use `stash_full_catalog` instead, which
+> fetches the catalog in chunks and handles retries automatically.
 
 The key difference from caching:
 
 - **Caching** (`mode='standard'`) — Stores the results of a specific query
   so the same query doesn't need to hit HEASARC again. The data is tied to
   that query's parameters.
-- **Mirroring** (`query_tap` + `mode='local'`) — Stores the entire table.
+- **Mirroring** (`stash_full_catalog` + `mode='local'`) — Stores the entire table.
   You can then run any spatial query against it locally, without any
   dependence on the HEASARC service.
 
@@ -257,6 +262,30 @@ Execute an ADQL query against the HEASARC Xamin TAP service.
 | `refresh` | `bool` | `False` | Force remote fetch |
 
 **Returns:** `pd.DataFrame` of query results.
+
+> **Note:** For full-catalog mirroring, prefer `stash_full_catalog` over
+> `query_tap` with `SELECT * FROM catalog`, especially for large tables.
+
+---
+
+#### `stash_full_catalog`
+
+```python
+stash_full_catalog(catalog, chunk_size=20000, max_retries=3) -> None
+```
+
+Fetch an entire HEASARC catalog and stash it to the local database in chunks.
+Solves the `DALOverflowWarning` issue that occurs when querying large catalogs
+with a single `SELECT * FROM catalog` query.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `catalog` | `str` | | Catalog table name (e.g., `'nicermastr'`) |
+| `chunk_size` | `int` | `20000` | Number of rows per query batch |
+| `max_retries` | `int` | `3` | Max retry attempts per chunk on network errors |
+
+**Returns:** `None`. After completion, use `query_region(..., mode='local')`
+for offline queries.
 
 ---
 


### PR DESCRIPTION
This PR introduces `Heasarc.stash_full_catalog` to solve the DALOverflowWarning issues encountered when attempting to mirror a large catalog from the heasarc as detailed in #19.

By creating  `Heasarc.stash_full_catalog` this should allow a user to much more easily collect and stash the larger catalogs from the HEASARC by chunking the amount of rows returned rather than grabbing the entire data table at once.

This PR will resolve #19.