### PR TITLE
Add default radius for Heasarc.query_object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.2.1
+
+## Bug Fixes
+- Added default radius for cone queries in local mode — fixes ValueError when radius not specified (#22)
+
+## Improvements
+- Created `Heasarc.stash_full_catalog` to fetch entire catalogs in chunks to avoid DALOverflowWarnings (#21)
+
 # v0.2.0
 
 ## New Features

--- a/astrostash/heasarc/core.py
+++ b/astrostash/heasarc/core.py
@@ -1,5 +1,6 @@
 import logging
 import astroquery.heasarc
+from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astrostash import SQLiteDB
@@ -76,6 +77,29 @@ class Heasarc:
         catalogs = self.list_catalogs()["name"].values
         return catalog in catalogs
 
+    def _get_default_radius(self, catalog: str):
+        """
+        Get the default search radius for a catalog.
+
+        First attempts to retrieve from astroquery's cached metadata, then
+        falls back to the class default if unavailable.
+
+        Parameters
+        ----------
+        catalog : str
+            Name of the catalog.
+
+        Returns
+        -------
+        `~astropy.units.Quantity`
+            The default radius in degrees.
+        """
+        try:
+            radius = self.aq.get_default_radius(catalog)
+            return radius.to(u.deg)
+        except (IndexError, KeyError):
+            return (0.1 * u.deg)
+
     def query_region(self, position=None, catalog=None,
                      radius=None, refresh_rate=None,
                      mode='standard', spatial='cone',
@@ -127,6 +151,8 @@ class Heasarc:
         if mode == 'local':
             if catalog is None:
                 raise ValueError("catalog is required for local queries")
+            if radius is None and spatial == 'cone':
+                radius = self._get_default_radius(catalog)
             return self.ldb.query_region(
                 table=catalog,
                 position=position,

--- a/astrostash/heasarc/tests/test_heasarc.py
+++ b/astrostash/heasarc/tests/test_heasarc.py
@@ -1,4 +1,5 @@
 from astrostash.heasarc import Heasarc
+from astropy import units as u
 from astropy.coordinates import SkyCoord
 import os
 import pathlib as pl
@@ -172,10 +173,10 @@ def test_query_region_local_missing_position(setup):
                            radius='1deg')
 
 
-def test_query_region_local_missing_radius(setup):
+def test_query_region_local_default_radius(setup):
     pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
-    with pytest.raises(ValueError, match="radius is required"):
-        setup.query_region(position=pos, catalog='nicermastr', mode='local')
+    result = setup.query_region(position=pos, catalog='nicermastr', mode='local')
+    assert not result.empty
 
 
 def test_query_region_local_box(setup):
@@ -234,3 +235,19 @@ def test_query_region_invalid_mode(setup):
     with pytest.raises(ValueError, match="Unknown mode"):
         setup.query_region(position=pos, catalog='nicermastr',
                            radius='0.5deg', mode='bogus')
+
+
+def test_get_default_radius_from_meta(setup):
+    radius = setup._get_default_radius('nicermastr')
+    assert radius.unit == u.deg
+    expected = 15.0 * u.arcmin.to(u.deg)
+    assert radius.value == pytest.approx(expected, rel=1e-6)
+
+
+def test_query_region_local_override_default_radius(setup):
+    pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
+    result_small = setup.query_region(
+        position=pos, catalog='nicermastr', radius='0.01deg', mode='local')
+    result_default = setup.query_region(
+        position=pos, catalog='nicermastr', mode='local')
+    assert len(result_small) < len(result_default)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "astrostash"
-version = "0.2.0"
+version = "0.2.1"
 description = "An astronomy/astrophysics database building and syncing library"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
This PR adds in a default search radius to `Heasarc.query_object` and will resolve #20.

It does this with the addition of the `Heasarc._get_default_radius` helper method which will try to use astroquery to get a catalog's default search radius before reverting to 0.1 deg. User specified radius still works. 

This change closes out the second of two improvements to v0.2.0 so I also bumped to v0.2.1.