### PR TITLE
Bug Fix: Handle duplicate rows when caching + mirroring or mirroring + caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.2.3
+
+## Bug Fixes
+- Fixed duplicate rows when caching via `query_region` then mirroring the full catalog (or vice versa) via `Heasarc.stash_full_catalog` by using ID-based deduplication (#27)
+
 # v0.2.2
 
 ## Improvements

--- a/astrostash/astrostash.py
+++ b/astrostash/astrostash.py
@@ -492,38 +492,35 @@ class SQLiteDB:
     def _stash_table(self, df: pd.DataFrame,
                      table_name: str, idcol: str) -> None:
         """
-        Merges the results of a query into a the designated table in
-        the database (if exists), or creates a new table and ingests the new
-        data
+        Merges the results of a query into the designated table in the
+        database (if exists), or creates a new table and ingests the new data.
 
         Parameters
         ----------
         df: pd.DataFrame, frame with response data from a query
 
-        table_name: str, name of the table/catlog in the database
+        table_name: str, name of the table/catalog in the database
 
         idcol: str, column name of the column to be used for id info
         """
+        if idcol not in df.columns:
+            raise ValueError(
+                f"idcol '{idcol}' not found in response DataFrame. "
+                f"Available columns: {list(df.columns)}")
+
         ta_exists = self._check_table_exists(table_name)
-        if ta_exists is True:
-            dd1 = pd.read_sql_table(table_name, self.aconn)
-            dd2 = pd.merge(df, dd1, how="left", indicator=True)
-            changes = dd2[
-                dd2["_merge"] == "left_only"
-                ].drop(columns="_merge")
-            if len(changes) > 0:
-                diffs = dd1[dd1[idcol].isin(changes[idcol])]
-                if len(diffs) > 0:
-                    idxs = diffs.index[0]
-                    dd1 = dd1.drop(idxs)
-                updated_table = pd.merge(dd1, df, how="outer")
-                self.ingest_table(updated_table,
-                                  table_name,
-                                  if_exists="replace")
-            else:
-                self.ingest_table(changes, table_name)
-        else:
+        if not ta_exists:
             self.ingest_table(df, table_name)
+            return
+
+        dd1 = pd.read_sql_table(table_name, self.aconn)
+        old_ids = set(dd1[idcol].astype(str))
+        new_ids = set(df[idcol].astype(str))
+        overlapping_ids = old_ids & new_ids
+        if overlapping_ids:
+            dd1 = dd1[~dd1[idcol].astype(str).isin(overlapping_ids)]
+        updated_table = pd.concat([dd1, df], ignore_index=True)
+        self.ingest_table(updated_table, table_name, if_exists="replace")
 
     def _get_stashed_rows(self, catalog: str,
                           qid: int, idcol: str) -> pd.DataFrame:

--- a/astrostash/heasarc/tests/test_heasarc.py
+++ b/astrostash/heasarc/tests/test_heasarc.py
@@ -130,6 +130,42 @@ def test_stash_full_catalog():
     os.remove("astrostash.db")
 
 
+@pytest.mark.remote
+def test_stash_cache_then_mirror():
+    h = Heasarc()
+    # Cache First
+    pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
+    h.query_region(position=pos, catalog='uhuru4', radius='5deg')
+    assert h.ldb._check_table_exists("uhuru4")
+    cached_count = len(
+        h.query_region(catalog='uhuru4', spatial='all-sky', mode='local'))
+    assert cached_count < 339
+    # Mirror full catalog
+    h.stash_full_catalog("uhuru4", chunk_size=200)
+    result = h.query_region(catalog="uhuru4", spatial="all-sky", mode="local")
+    assert len(result) == 339
+    assert result["__row"].is_unique
+    os.remove("astrostash.db")
+
+
+@pytest.mark.remote
+def test_stash_mirror_then_cache():
+    h = Heasarc()
+    # Mirror first
+    h.stash_full_catalog("uhuru4", chunk_size=200)
+    assert h.ldb._check_table_exists("uhuru4")
+    full_count = len(
+        h.query_region(catalog="uhuru4", spatial="all-sky", mode="local"))
+    assert full_count == 339
+    # Cache second
+    pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
+    h.query_region(position=pos, catalog='uhuru4', radius='5deg')
+    result = h.query_region(catalog="uhuru4", spatial="all-sky", mode="local")
+    assert len(result) == 339
+    assert result["__row"].is_unique
+    os.remove("astrostash.db")
+
+
 def test_query_region_local_cone(setup):
     pos = SkyCoord(ra=83.633, dec=22.015, unit='deg')
     result = setup.query_region(position=pos, catalog='nicermastr',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "astrostash"
-version = "0.2.2"
+version = "0.2.3"
 description = "An astronomy/astrophysics database building and syncing library"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Fixed duplicate rows that appear when a user caches data via `query_region` (which returns only default columns) and then mirrors the full catalog via `stash_full_catalog` (which uses `SELECT *` and returns all columns). The reverse order (mirror then cache) was also affected.

This PR addresses and will resolve #23. This also merits a bump to v0.2.3.

## Root Cause

`SQLiteDB._stash_table` used a column-value-based `pd.merge(..., how="left", indicator=True)` to detect changes between new and existing data. This approach has two defects:

1. **Merged on all shared columns** instead of using the `idcol` so any column value difference caused the merge to treat an existing row as new
2. **Outer merge produced duplicates**  `pd.merge(..., how="outer")` created separate rows for overlapping IDs

## Changes

### `astrostash/astrostash.py`

Rewrote `_stash_table` to use ID-based deduplication:

- Computes set intersection of old and new IDs via `idcol.astype(str)`
- Removes all old rows with overlapping IDs (not just one)
- Appends new rows via `pd.concat` — guaranteed no overlap by construction
- Validates `idcol` exists in the response DataFrame upfront, raising a clear `ValueError` if missing

### `astrostash/heasarc/tests/test_heasarc.py`

Added two `@pytest.mark.remote` tests using the small `uhuru4` catalog:

- `test_stash_cache_then_mirror` — cache a cone region, then mirror the full catalog. Asserts 339 rows and unique `__row`.
- `test_stash_mirror_then_cache` — mirror the full catalog, then cache a cone region. Asserts table unchanged at 339 rows with unique `__row`.
