### PR TITLE
Fix astroquery cache interfering with mode='refresh'

### DIFF
--- a/astrostash/astrostash.py
+++ b/astrostash/astrostash.py
@@ -637,6 +637,8 @@ class BaseDB(ABC):
                 qid = self.insert_query(query_hash, refresh_rate)
             else:
                 self.update_last_refreshed(qid)
+            if refresh and hasattr(query_func, '__self__'):
+                query_func.__self__.clear_cache()
             try:
                 df = query_func(*args,
                                 **query_params,

--- a/astrostash/tests/test_astrostash_core.py
+++ b/astrostash/tests/test_astrostash_core.py
@@ -174,6 +174,40 @@ def test_fetch_sync(setup_sqlite_db):
     run_test(True, mock_df3)
 
 
+def test_clear_aq_cache_on_refresh(setup_sqlite_db):
+    sql, db_path = setup_sqlite_db
+
+    mock_aq_instance = MagicMock()
+    mock_query_func = MagicMock()
+    mock_query_func.__self__ = mock_aq_instance
+    mock_query_func.return_value = Table.from_pandas(
+        pd.DataFrame({'__row': ['1'], 'col1': ['a']})
+    )
+
+    query_params = {'param1': 'value1', 'refresh_rate': 7, 'refresh': True}
+    sql.fetch_sync(mock_query_func, 'test_table', query_params, None,
+                   refresh=True)
+
+    mock_aq_instance.clear_cache.assert_called_once()
+
+
+def test_no_clear_cache_without_refresh(setup_sqlite_db):
+    sql, db_path = setup_sqlite_db
+
+    mock_aq_instance = MagicMock()
+    mock_query_func = MagicMock()
+    mock_query_func.__self__ = mock_aq_instance
+    mock_query_func.return_value = Table.from_pandas(
+        pd.DataFrame({'__row': ['1'], 'col1': ['a']})
+    )
+
+    query_params = {'param1': 'value1', 'refresh_rate': 7, 'refresh': False}
+    sql.fetch_sync(mock_query_func, 'test_table', query_params, None,
+                   refresh=False)
+
+    mock_aq_instance.clear_cache.assert_not_called()
+
+
 def test_insert_local_data_path(setup_sqlite_db):
     sql = setup_sqlite_db[0]
     demo_product_path = "/DEMO/PATH/TO/nicermastr/1013010107/"


### PR DESCRIPTION
This PR solves a bug with astroquery 1 week cache's by default. When astrostash calls `mode='refresh'`, it bypasses its own local DB but astroquery still returns cached responses from disk (via astroquery) if within the same week of the original query. This breaks both `mode='refresh'` and `refresh_rate` auto-refresh functionality, or at the very least make it inconisitent with the intended functionality of `mode='refresh'` triggering a network request.

## Fix

I added `clear_cache()` call in `fetch_sync` before executing the remote query when `refresh=True`. Guarded with `hasattr(query_func, '__self__')` because tests pass bare `MagicMock` objects without `__self__`.